### PR TITLE
Update Claude workflow permissions to allow code changes

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,9 +19,9 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:


### PR DESCRIPTION
## Summary
- Updates `claude.yml` permissions from `read` to `write` for `contents`, `pull-requests`, and `issues`

## Why
Allows Claude to directly commit code changes and create/update PRs when asked via `@claude` comments.