### PR TITLE
Allow Bash tool access in Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -40,11 +40,6 @@ jobs:
           additional_permissions: |
             actions: read
 
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
-
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
+          # Pre-approve tools so Claude can commit and push changes without manual approval
+          allowed_tools: "Bash,Edit,Read,Write,Glob,Grep"
 


### PR DESCRIPTION
## Summary
- Adds `allowed_tools: "Bash,Edit,Read,Write,Glob,Grep"` to `claude.yml`
- Fixes the "Bash tool access was not approved" error when Claude tries to commit and push changes